### PR TITLE
Add theme and feral mode toggles

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -81,29 +81,24 @@ const THREE_FACTS_ONE_LIE = [
   "First C# job offer was from a C# code assessment in front of a panel. I had never worked with C# before the interview."
 ];
 
-function mainClasses(feral: boolean) {
-  return `px-3 md:px-6 lg:px-10 py-6 md:py-10 ${feral ? "noise" : ""}`;
-}
 ---
 
 <Layout title="Jacob Stovall - Software Developer" description="Arizona based software developer since 2016.">
-  <div class={`${dark ? "bg-black text-white" : "bg-white text-black"} min-h-screen font-mono antialiased`}> 
+  <div id="page" class="min-h-screen font-mono antialiased bg-white text-black dark:bg-black dark:text-white">
 
       <header class="border-b-8 border-current">
         <div class="px-3 py-2 flex items-center justify-between gap-3">
           <div class="uppercase tracking-tighter leading-none text-xl md:text-2xl">
             {ME.name} // {ME.title} // {ME.location} (Always)
           </div>
-          {/* For now just keep it simple
           <div class="flex items-center gap-2">
-            <button onClick={()=>setFeral(v=>!v)} class="px-3 py-2 border-4 border-current active:translate-x-1 active:translate-y-1">
+            <button id="feral-btn" class="px-3 py-2 border-4 border-current active:translate-x-1 active:translate-y-1">
               {feral ? "Tame layout" : "Break layout"}
             </button>
-            <button onClick={()=>setDark(d=>!d)} class="px-3 py-2 border-4 border-current active:translate-x-1 active:translate-y-1" aria-pressed={dark}>
-              {dark?"Light":"Dark"}
+            <button id="theme-btn" class="px-3 py-2 border-4 border-current active:translate-x-1 active:translate-y-1" aria-pressed={dark}>
+              {dark ? "Light" : "Dark"}
             </button>
           </div>
-          */}
         </div>
         {/* marquee strip */}
         <div class="overflow-hidden border-t-8 border-current">
@@ -115,9 +110,9 @@ function mainClasses(feral: boolean) {
         </div>
       </header>
 
-      <main class={mainClasses(feral)}>
-        <div class={`grid grid-cols-12 auto-rows-[minmax(60px,_auto)] gap-3 md:gap-4 ${feral?"[&_*]:transition-transform [&_.card]:duration-200" : ""}`}>
-          <section class={`card col-span-12 md:col-span-8 lg:col-span-7 ${feral?"-rotate-1 -translate-y-1":""}`}>
+      <main class="px-3 md:px-6 lg:px-10 py-6 md:py-10" data-feral-class="noise">
+        <div class="grid grid-cols-12 auto-rows-[minmax(60px,_auto)] gap-3 md:gap-4" data-feral-class="[&_*]:transition-transform [&_.card]:duration-200">
+          <section class="card col-span-12 md:col-span-8 lg:col-span-7" data-feral-class="-rotate-1 -translate-y-1">
             <div class="border-8 border-current p-4 md:p-6">
               <h1 class="uppercase font-black leading-[0.9] tracking-tighter text-[12vw] md:text-[9vw] lg:text-[7vw]" style={{textShadow:"8px 8px 0 currentColor"}}>
                 {ME.name}
@@ -129,7 +124,7 @@ function mainClasses(feral: boolean) {
           </section>
 
           {/* STAT BLOCK */}
-          <aside class={`card col-span-12 md:col-span-4 lg:col-span-5 ${feral?"rotate-1 translate-y-1":""}`}>
+          <aside class="card col-span-12 md:col-span-4 lg:col-span-5" data-feral-class="rotate-1 translate-y-1">
             <div class="border-8 border-current p-4">
               <div class="grid grid-cols-2 gap-2 text-xs md:text-sm">
                 <div class="border-4 border-current p-2">BASE<br/><span class="text-lg md:text-xl">{ME.location}</span></div>
@@ -141,8 +136,8 @@ function mainClasses(feral: boolean) {
           </aside>
 
           {/* Three Facts, One Lie: reversed color block */}
-          <section class={`card col-span-12 md:col-span-7 lg:col-span-6 ${feral?"-rotate-1":""}`}>
-            <div class={`${dark?"bg-white text-black":"bg-black text-white"} p-4 md:p-6 border-8 border-current`}> 
+          <section class="card col-span-12 md:col-span-7 lg:col-span-6" data-feral-class="-rotate-1">
+            <div class="p-4 md:p-6 border-8 border-current bg-black text-white dark:bg-white dark:text-black">
               <h2 class="uppercase text-2xl md:text-3xl">Three Facts, One Lie</h2>
               <div class="mt-4 text-sm md:text-base">
                 <ul class="mt-2 list-disc pl-5">
@@ -153,7 +148,7 @@ function mainClasses(feral: boolean) {
           </section>
 
           {/* Skills */}
-          <div class={`card col-span-12 md:col-span-5 lg:col-span-6 ${feral?"rotate-1":""}`}>
+          <div class="card col-span-12 md:col-span-5 lg:col-span-6" data-feral-class="rotate-1">
             <div class="border-8 border-current p-4">
               <h2 class="uppercase text-2xl md:text-3xl">Skills</h2>
               <ul class="mt-3 space-y-2 text-sm">
@@ -167,7 +162,7 @@ function mainClasses(feral: boolean) {
           </div>
 
           {/* EXPERIENCE: two-column rule list */}
-          <section class={`card col-span-12 lg:col-span-12 ${!feral?"-rotate-1 -translate-y-1":""}`}>
+          <section class="card col-span-12 lg:col-span-12" data-feral-class="-rotate-1 -translate-y-1">
             <div class="border-8 border-current p-4 md:p-6">
               <h2 class="uppercase text-2xl md:text-3xl">Experience</h2>
               <div class="mt-4 space-y-6">
@@ -185,7 +180,7 @@ function mainClasses(feral: boolean) {
           </section>
 
           {/* CONTACT: harsh form imitation */}
-          <section class={`card col-span-12 ${feral?"-rotate-1":""}`}>
+          <section class="card col-span-12" data-feral-class="-rotate-1">
             <div class="border-8 border-current p-4 md:p-6">
               <h2 class="uppercase text-2xl md:text-3xl">Contact</h2>
               <div class="mt-3 grid md:grid-cols-[1fr_auto] gap-3">
@@ -202,6 +197,35 @@ function mainClasses(feral: boolean) {
       <footer class="border-t-8 border-current px-3 md:px-6 lg:px-10 py-4 text-xs text-right">
         <span class="inline-block border-4 border-current px-2 py-1">© {new Date().getFullYear()} {ME.name} — Built with Astro + Tailwind.</span>
       </footer>
+      <script>
+        let feral = false;
+        let dark = true;
+        const root = document.documentElement;
+        const feralBtn = document.getElementById('feral-btn')!;
+        const themeBtn = document.getElementById('theme-btn')!;
+        function applyFeral() {
+          document.querySelectorAll('[data-feral-class]').forEach((el) => {
+            const classes = (el.getAttribute('data-feral-class') || '').split(' ').filter(Boolean);
+            classes.forEach((cls) => {
+              if (feral) {
+                el.classList.add(cls);
+              } else {
+                el.classList.remove(cls);
+              }
+            });
+          });
+          feralBtn.textContent = feral ? 'Tame layout' : 'Break layout';
+        }
+        function applyDark() {
+          root.classList.toggle('dark', dark);
+          themeBtn.setAttribute('aria-pressed', dark.toString());
+          themeBtn.textContent = dark ? 'Light' : 'Dark';
+        }
+        feralBtn.addEventListener('click', () => { feral = !feral; applyFeral(); });
+        themeBtn.addEventListener('click', () => { dark = !dark; applyDark(); });
+        applyFeral();
+        applyDark();
+      </script>
   </div>
 </Layout>
 

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -84,7 +84,12 @@ const THREE_FACTS_ONE_LIE = [
 ---
 
 <Layout title="Jacob Stovall - Software Developer" description="Arizona based software developer since 2016.">
-  <div id="page" class="min-h-screen font-mono antialiased bg-white text-black dark:bg-black dark:text-white">
+  <div
+    id="page"
+    class={`${dark ? "bg-black text-white" : "bg-white text-black"} min-h-screen font-mono antialiased`}
+    data-dark-class="bg-black text-white"
+    data-light-class="bg-white text-black"
+  >
 
       <header class="border-b-8 border-current">
         <div class="px-3 py-2 flex items-center justify-between gap-3">
@@ -137,7 +142,12 @@ const THREE_FACTS_ONE_LIE = [
 
           {/* Three Facts, One Lie: reversed color block */}
           <section class="card col-span-12 md:col-span-7 lg:col-span-6" data-feral-class="-rotate-1">
-            <div class="p-4 md:p-6 border-8 border-current bg-black text-white dark:bg-white dark:text-black">
+            <div
+              id="facts-block"
+              class={`${dark ? "bg-white text-black" : "bg-black text-white"} p-4 md:p-6 border-8 border-current`}
+              data-dark-class="bg-white text-black"
+              data-light-class="bg-black text-white"
+            >
               <h2 class="uppercase text-2xl md:text-3xl">Three Facts, One Lie</h2>
               <div class="mt-4 text-sm md:text-base">
                 <ul class="mt-2 list-disc pl-5">
@@ -200,7 +210,6 @@ const THREE_FACTS_ONE_LIE = [
       <script>
         let feral = false;
         let dark = true;
-        const root = document.documentElement;
         const feralBtn = document.getElementById('feral-btn')!;
         const themeBtn = document.getElementById('theme-btn')!;
         function applyFeral() {
@@ -217,7 +226,17 @@ const THREE_FACTS_ONE_LIE = [
           feralBtn.textContent = feral ? 'Tame layout' : 'Break layout';
         }
         function applyDark() {
-          root.classList.toggle('dark', dark);
+          document.querySelectorAll('[data-dark-class]').forEach((el) => {
+            const darkClasses = (el.getAttribute('data-dark-class') || '').split(' ').filter(Boolean);
+            const lightClasses = (el.getAttribute('data-light-class') || '').split(' ').filter(Boolean);
+            if (dark) {
+              lightClasses.forEach((cls) => el.classList.remove(cls));
+              darkClasses.forEach((cls) => el.classList.add(cls));
+            } else {
+              darkClasses.forEach((cls) => el.classList.remove(cls));
+              lightClasses.forEach((cls) => el.classList.add(cls));
+            }
+          });
           themeBtn.setAttribute('aria-pressed', dark.toString());
           themeBtn.textContent = dark ? 'Light' : 'Dark';
         }

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -214,7 +214,7 @@ const THREE_FACTS_ONE_LIE = [
         const themeBtn = document.getElementById('theme-btn')!;
         function applyFeral() {
           document.querySelectorAll('[data-feral-class]').forEach((el) => {
-            const classes = (el.getAttribute('data-feral-class') || '').split(' ').filter(Boolean);
+            const classes = (el.getAttribute('data-feral-class') || '').split(' ');
             classes.forEach((cls) => {
               if (feral) {
                 el.classList.add(cls);
@@ -227,8 +227,8 @@ const THREE_FACTS_ONE_LIE = [
         }
         function applyDark() {
           document.querySelectorAll('[data-dark-class]').forEach((el) => {
-            const darkClasses = (el.getAttribute('data-dark-class') || '').split(' ').filter(Boolean);
-            const lightClasses = (el.getAttribute('data-light-class') || '').split(' ').filter(Boolean);
+            const darkClasses = (el.getAttribute('data-dark-class') || '').split(' ');
+            const lightClasses = (el.getAttribute('data-light-class') || '').split(' ');
             if (dark) {
               lightClasses.forEach((cls) => el.classList.remove(cls));
               darkClasses.forEach((cls) => el.classList.add(cls));
@@ -242,8 +242,6 @@ const THREE_FACTS_ONE_LIE = [
         }
         feralBtn.addEventListener('click', () => { feral = !feral; applyFeral(); });
         themeBtn.addEventListener('click', () => { dark = !dark; applyDark(); });
-        applyFeral();
-        applyDark();
       </script>
   </div>
 </Layout>


### PR DESCRIPTION
## Summary
- enable header buttons to toggle dark/light theme and feral layout
- wire up front-end script for runtime theme and layout changes
- fix experience section to use feral state directly

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689a819f3ff88323a91b38a6619fd146